### PR TITLE
This tells the backend to accept "Easy" instead of 0, "JavaScript" in…

### DIFF
--- a/src/BugArena.API/Program.cs
+++ b/src/BugArena.API/Program.cs
@@ -74,7 +74,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     });
 
 builder.Services.AddAuthorization();
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(
+            new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 builder.Services.AddValidatorsFromAssemblyContaining<CreateChallengeValidator>();
 builder.Services.AddEndpointsApiExplorer();
 


### PR DESCRIPTION
…stead of a number, etc. It works for all enums across your whole API.